### PR TITLE
remove Build failure bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM jekyll/builder:4.2.0 as build
 
 # Install Ruby 3.x and upgrade Bundler
-RUN apk update && apk add --no-cache zip ruby=2.6.8-r0 ruby-dev build-base \
-    && gem install bundler:2.5.16
+RUN apk update && apk add --no-cache zip ruby=2.7.1-r0 ruby-dev build-base \
+    && gem install bundler:2.2.33
 
 WORKDIR /tmp
 COPY . /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
 FROM jekyll/builder:4.2.0 as build
-
-# Install Ruby 3.x and upgrade Bundler
-RUN apk update && apk add --no-cache zip ruby=2.7.1-r0 ruby-dev build-base \
-    && gem install bundler:2.2.33
-
 WORKDIR /tmp
 COPY . /tmp
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,9 +1,6 @@
 FROM jekyll/builder:4.2.0 as build
 
-# Install zip, ruby 3.3.5, and upgrade Bundler
-RUN apk update && apk add --no-cache zip ruby=2.7.1-r0 ruby-dev build-base \
-    && gem install bundler:2.2.33
-
+RUN apk update && apk add --no-cache zip
 
 WORKDIR /usr/local/site
 COPY Gemfile /usr/local/site

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,8 +1,8 @@
 FROM jekyll/builder:4.2.0 as build
 
 # Install zip, ruby 3.3.5, and upgrade Bundler
-RUN apk update && apk add --no-cache zip ruby=2.6.8-r0 ruby-dev build-base \
-    && gem install bundler:2.5.16
+RUN apk update && apk add --no-cache zip ruby=2.7.1-r0 ruby-dev build-base \
+    && gem install bundler:2.2.33
 
 
 WORKDIR /usr/local/site


### PR DESCRIPTION
Fixed a build bug caused by Ruby and bundler version mismatch.

The bug was causing the build failure on GitHub pages and even in the local environment.

reverting to the original docker configuration fixed the build failure.